### PR TITLE
Fix for issue #2 and add Stylus output option

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -4,7 +4,7 @@ module.exports = decode
 
 var errors = {
     header: 'Not a valid .ASE file'
-  , unexpected: 'Unexpected state. This is a bug!'
+        , unexpected: 'Unexpected state. This is a bug!'
 }
 
 var COLOR_START = 0x0001
@@ -23,137 +23,178 @@ var STATE_GET_TYPE   = 6
 
 var colorSizes = {
     CMYK: 4
-  , RGB: 3
-  , LAB: 3
-  , GRAY: 1
+        , RGB: 3
+        , LAB: 3
+        , GRAY: 1
 }
 
 var colorTypes = {
     0: 'global'
-  , 1: 'spot'
-  , 2: 'normal'
+    , 1: 'spot'
+    , 2: 'normal'
 }
 
-function decode(buffer) {
-  if (typeof buffer === 'string') {
-    buffer = Buffer(buffer)
-  }
+function decode(buffer, outputType) {
+    if (typeof buffer === 'string') {
+        buffer = Buffer(buffer)
+    }
+     
+    var output = {}
+    var groups = output.groups = []
+    var colors = output.colors = []
 
-  var output = {}
-  var groups = output.groups = []
-  var colors = output.colors = []
+    assert(getChar8(0) === 'A', errors.header)
+    assert(getChar8(1) === 'S', errors.header)
+    assert(getChar8(2) === 'E', errors.header)
+    assert(getChar8(3) === 'F', errors.header)
 
-  assert(getChar8(0) === 'A', errors.header)
-  assert(getChar8(1) === 'S', errors.header)
-  assert(getChar8(2) === 'E', errors.header)
-  assert(getChar8(3) === 'F', errors.header)
+    output.version = [
+        buffer.readUInt16BE(4)
+        , buffer.readUInt16BE(6)
+    ].join('.')
 
-  output.version = [
-      buffer.readUInt16BE(4)
-    , buffer.readUInt16BE(6)
-  ].join('.')
+    var blocks = buffer.readUInt32BE(8)
+    var state = STATE_GET_MODE
+    var mode = MODE_COLOR
+    var position = 12
+    var blockLength
+    var block
+    var group
+    var color
 
-  var blocks = buffer.readUInt32BE(8)
-  var state = STATE_GET_MODE
-  var mode = MODE_COLOR
-  var position = 12
-  var blockLength
-  var block
-  var group
-  var color
+    x: while (position < buffer.length) {
+        switch (state) {
+            case STATE_GET_MODE:   readBlockMode();   continue x
+            case STATE_GET_LENGTH: readBlockLength(); continue x
+            case STATE_GET_NAME:   readBlockName();   continue x
+            case STATE_GET_MODEL:  readBlockModel();  continue x
+            case STATE_GET_COLOR:  readBlockColor();  continue x
+            case STATE_GET_TYPE:   readBlockType();   continue x
+        }
+        throw new Error(errors.unexpected)
+    }
+    
+    
 
-  x: while (position < buffer.length) {
-    switch (state) {
-      case STATE_GET_MODE:   readBlockMode();   continue x
-      case STATE_GET_LENGTH: readBlockLength(); continue x
-      case STATE_GET_NAME:   readBlockName();   continue x
-      case STATE_GET_MODEL:  readBlockModel();  continue x
-      case STATE_GET_COLOR:  readBlockColor();  continue x
-      case STATE_GET_TYPE:   readBlockType();   continue x
+    switch (outputType) {
+        case "json": output = outputJSON(output); break
+        case "stylus": output = outputStylus(output); break
     }
 
-    throw new Error(errors.unexpected)
-  }
+    console.log(output);
+    return output
 
-  return output
+    function readBlockMode() {
+        switch (buffer.readUInt16BE(position)) {
+            case COLOR_START: 
+                colors.push(block = color = {})
+                mode = MODE_COLOR
+                break
+            case GROUP_START: 
+                groups.push(block = group = { colors: [] })
+                mode = MODE_GROUP
+                break
+            case GROUP_END: 
+                group = null
+                break
 
-  function readBlockMode() {
-    switch (buffer.readUInt16BE(position)) {
-      case COLOR_START: colors.push(block = color = {}); break
-      case GROUP_START: groups.push(block = group = { colors: [] }); break
-      case GROUP_END: group = null; break
+            default:
+                throw new Error('Unexpected block type at byte #' + position)
+        }
 
-      default:
-        throw new Error('Unexpected block type at byte #' + position)
+        if (group && block === color) {
+            group.colors.push(color)
+        }
+
+        position += 2
+        state = STATE_GET_LENGTH
     }
 
-    if (group && block === color) {
-      group.colors.push(color)
+    function readBlockLength() {
+        //doesn't appear to be reading the block length correctly
+        //does on the first block, but then fails on the second.
+        blockLength = buffer.readUInt32BE(position)
+        position += 4
+        state = STATE_GET_NAME
     }
 
-    position += 2
-    state = STATE_GET_LENGTH
-  }
-
-  function readBlockLength() {
-    blockLength = buffer.readUInt32BE(position)
-    position += 4
-    state = STATE_GET_NAME
-  }
-
-  function readBlockName() {
-    var length = buffer.readUInt16BE(position)
-    var name = ''
-
-    while (--length) {
-      name += getChar16(position += 2)
+    function readBlockName() {
+        var length = buffer.readUInt16BE(position)
+        var name = ''
+        while (--length) {
+            name += getChar16(position += 2);
+            
+        }
+        position += 4
+        block.name = name
+        state = mode === MODE_GROUP
+            ? STATE_GET_MODE
+            : STATE_GET_MODEL
     }
 
-    position += 4
-    block.name = name
-
-    state = mode === MODE_GROUP
-      ? STATE_GET_MODE
-      : STATE_GET_MODEL
-  }
-
-  function readBlockModel() {
-    block.model = (
-      getChar8(position++) +
-      getChar8(position++) +
-      getChar8(position++) +
-      getChar8(position++)
-    ).trim()
-
-    state = STATE_GET_COLOR
-  }
-
-  function readBlockColor() {
-    var model = block.model.toUpperCase()
-    var count = colorSizes[model]
-    var channels = []
-
-    while (count--) {
-      channels.push(buffer.readFloatBE(position))
-      position += 4
+    function readBlockModel() {
+        block.model = (
+            getChar8(position++) +
+            getChar8(position++) +
+            getChar8(position++) +
+            getChar8(position++)
+        ).trim()
+        state = STATE_GET_COLOR
     }
 
-    block.color = channels
+    function readBlockColor() {
+        var model = block.model.toUpperCase()
+        var count = colorSizes[model]
+        var channels = []
 
-    state = STATE_GET_TYPE
-  }
+        while (count--) {
+            channels.push(buffer.readFloatBE(position))
+            position += 4
+        }
 
-  function readBlockType() {
-    block.type = colorTypes[buffer.readUInt16BE(position)]
-    position += 2
-    state = STATE_GET_MODE
-  }
+        block.color = channels
+        state = STATE_GET_TYPE
+    }
 
-  function getChar8(index) {
-    return String.fromCharCode(buffer.readUInt8(index))
-  }
+    function readBlockType() {
+        block.type = colorTypes[buffer.readUInt16BE(position)]
+        position += 2
+        state = STATE_GET_MODE
+    }
 
-  function getChar16(index) {
-    return String.fromCharCode(buffer.readUInt16BE(index))
-  }
+    function getChar8(index) {
+        return String.fromCharCode(buffer.readUInt8(index))
+    }
+
+    function getChar16(index) {
+        return String.fromCharCode(buffer.readUInt16BE(index))
+    }
+
+    function outputJSON(output){
+       var jsonOut = JSON.stringify(output) 
+       return jsonOut 
+    }
+
+    function outputStylus(output){
+        var colors = output.colors
+        var colorCount = 1
+        var stylusOut = {}
+
+        output.colors.forEach(function(item){
+            if(item.name === ''){
+                var name = "color" + colorCount
+                colorCount++
+            }
+            else{
+                var name = item.name
+            }
+            
+            if(item.model === "RGB"){
+                stylusOut[name] = "rgb("+item.color[0]*255+","+item.color[1]*255+","+item.color[2]*255+")";
+            }
+            
+        });
+        stylusOut = JSON.stringify(stylusOut)
+        return stylusOut
+    }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
   "scripts": {
     "test": "node test | faucet"
   },
-  "author": "Hugh Kennedy <hughskennedy@gmail.com> (http://hughsk.io/)",
+  "author": {
+    "name": "Hugh Kennedy",
+    "email": "hughskennedy@gmail.com",
+    "url": "http://hughsk.io/"
+  },
   "license": "MIT",
   "homepage": "http://hughsk.github.io/adobe-swatch-exchange",
   "repository": {
@@ -20,5 +24,11 @@
   },
   "bugs": {
     "url": "https://github.com/hughsk/adobe-swatch-exchange/issues"
-  }
+  },
+  "readme": "# adobe-swatch-exchange [![experimental](http://hughsk.github.io/stability-badges/dist/experimental.svg)](http://github.com/hughsk/stability-badges) #\n\nEncode/decode color palettes in Adobe's `.ase` format.\n\n## Usage ##\n\n[![adobe-swatch-exchange](https://nodei.co/npm/adobe-swatch-exchange.png?mini=true)](https://nodei.co/npm/adobe-swatch-exchange)\n\n### ase.decode(buffer) ###\n\nReturns a JSON object representing the contents of the `.ase` file, for example:\n\n``` json\n{\n  \"version\": \"1.0\",\n  \"groups\": [],\n  \"colors\": [{\n    \"name\": \"RGB Red\",\n    \"model\": \"RGB\",\n    \"color\": [1, 0, 0],\n    \"type\": \"global\"\n  }, {\n    \"name\": \"RGB Yellow\",\n    \"model\": \"RGB\",\n    \"color\": [1, 1, 0],\n    \"type\": \"global\"\n  }]\n}\n```\n\n## License ##\n\nMIT. See [LICENSE.md](http://github.com/hughsk/adobe-swatch-exchange/blob/master/LICENSE.md) for details.\n",
+  "readmeFilename": "README.md",
+  "_id": "adobe-swatch-exchange@0.0.0",
+  "_shasum": "27ecb7fc7a1b7000ab8f878fd7e8e18767546e43",
+  "_from": "adobe-swatch-exchange@",
+  "_resolved": "https://registry.npmjs.org/adobe-swatch-exchange/-/adobe-swatch-exchange-0.0.0.tgz"
 }


### PR DESCRIPTION
Fix for issue #2. Block mode wasn't being set, but is now. Also added JSON.stringify() to actually output JSON, as well as the ability to output colors to Stylus-friendly JSON, for easy importing of .ase swatches into stylesheets.
